### PR TITLE
feat: add feed hook and infinite scroll

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,60 +1,28 @@
-import type { Question } from "@/types";
+"use client";
+
+import { useEffect, useRef } from "react";
 import Header from "@/components/Header";
 import QuestionCard from "@/components/QuestionCard";
-
-const questions: Question[] = [
-  {
-    id: 1,
-    author: {
-      name: 'Startup Sam',
-      avatarUrl: 'https://placehold.co/40x40.png',
-    },
-    questionText: 'Is remote work the future for all tech companies?',
-    initialYesVotes: 256,
-    initialNoVotes: 88,
-    commentsCount: 64,
-    createdAt: '2h ago',
-  },
-  {
-    id: 2,
-    author: {
-      name: 'Design Dana',
-      avatarUrl: 'https://placehold.co/40x40.png',
-    },
-    questionText: 'Should designers learn to code?',
-    initialYesVotes: 420,
-    initialNoVotes: 150,
-    commentsCount: 128,
-    createdAt: '5h ago',
-  },
-  {
-    id: 3,
-    author: {
-      name: 'Foodie Frank',
-      avatarUrl: 'https://placehold.co/40x40.png',
-    },
-    questionText: 'Is pineapple on pizza a crime against humanity?',
-    initialYesVotes: 180,
-    initialNoVotes: 320,
-    commentsCount: 256,
-    createdAt: '1d ago',
-  },
-  {
-    id: 4,
-    author: {
-      name: 'Travel Tina',
-      avatarUrl: 'https://placehold.co/40x40.png',
-    },
-    questionText: 'Do you prefer mountains or beaches for a vacation?',
-    initialYesVotes: 512,
-    initialNoVotes: 488,
-    commentsCount: 96,
-    createdAt: '2d ago',
-  },
-];
-
+import { useFeed } from "@/hooks/useFeed";
 
 export default function Home() {
+  const { questions, loadMore, hasMore } = useFeed();
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!hasMore) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        loadMore();
+      }
+    });
+    const node = loadMoreRef.current;
+    if (node) observer.observe(node);
+    return () => {
+      if (node) observer.unobserve(node);
+    };
+  }, [loadMore, hasMore]);
+
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
@@ -64,6 +32,7 @@ export default function Home() {
           {questions.map((q) => (
             <QuestionCard key={q.id} question={q} />
           ))}
+          {hasMore && <div ref={loadMoreRef} className="h-1" />}
         </div>
       </main>
     </div>

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { Question } from "@/types";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+type QuestionWithAuthorId = Question & { authorId: string };
+
+export function useFeed(pageSize = 10) {
+  const { user } = useAuth();
+  const [questions, setQuestions] = useState<QuestionWithAuthorId[]>([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const fetchFollowedIds = useCallback(async () => {
+    if (!user || !supabaseUrl || !supabaseKey) return [] as string[];
+    const res = await fetch(
+      `${supabaseUrl}/rest/v1/follows?select=following_id&follower_id=eq.${user.uid}`,
+      {
+        headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+      }
+    );
+    if (!res.ok) return [] as string[];
+    const data = await res.json();
+    return data.map((f: any) => f.following_id as string);
+  }, [user]);
+
+  const loadMore = useCallback(async () => {
+    if (loading || !hasMore || !supabaseUrl || !supabaseKey) return;
+    setLoading(true);
+
+    const followedIds = await fetchFollowedIds();
+
+    const from = page * pageSize;
+    const to = from + pageSize - 1;
+    const res = await fetch(
+      `${supabaseUrl}/rest/v1/questions?select=id,question_text,yes_votes,no_votes,comments_count,created_at,author_id,profiles!inner(name,avatar_url)&order=created_at.desc`,
+      {
+        headers: {
+          apikey: supabaseKey,
+          Authorization: `Bearer ${supabaseKey}`,
+          Range: `${from}-${to}`,
+        },
+      }
+    );
+    if (!res.ok) {
+      setLoading(false);
+      return;
+    }
+    const data = await res.json();
+    const mapped: QuestionWithAuthorId[] = data.map((q: any) => ({
+      id: q.id,
+      authorId: q.author_id,
+      author: {
+        name: q.profiles?.name ?? "",
+        avatarUrl: q.profiles?.avatar_url ?? "",
+      },
+      questionText: q.question_text,
+      initialYesVotes: q.yes_votes ?? 0,
+      initialNoVotes: q.no_votes ?? 0,
+      commentsCount: q.comments_count ?? 0,
+      createdAt: q.created_at,
+    }));
+
+    setQuestions(prev =>
+      [...prev, ...mapped].sort((a, b) => {
+        const aFollowed = followedIds.includes(a.authorId) ? 1 : 0;
+        const bFollowed = followedIds.includes(b.authorId) ? 1 : 0;
+        if (aFollowed !== bFollowed) return bFollowed - aFollowed;
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      })
+    );
+
+    if (mapped.length < pageSize) {
+      setHasMore(false);
+    } else {
+      setPage(prev => prev + 1);
+    }
+    setLoading(false);
+  }, [fetchFollowedIds, page, pageSize, loading, hasMore]);
+
+  useEffect(() => {
+    loadMore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { questions: questions as Question[], loadMore, hasMore, loading };
+}
+


### PR DESCRIPTION
## Summary
- add useFeed hook to fetch paginated questions from Supabase and prioritize followed users
- implement infinite scrolling on home page with IntersectionObserver
- remove temporary hard-coded questions list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompted for ESLint configuration)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a617a05d708331a7ff21e23f0cfa73