### PR TITLE
feat: add admin view and supabase policies

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,5 @@
+import AdminGuard from '@/contexts/AdminGuard';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+type Question = { id: string; question_text: string };
+
+export default function AdminPage() {
+  const [activeQuestions, setActiveQuestions] = useState<Question[]>([]);
+  const [closedQuestions, setClosedQuestions] = useState<Question[]>([]);
+
+  const fetchQuestions = async () => {
+    if (!supabaseUrl || !supabaseKey) return;
+    const headers = { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` };
+    const [activeRes, closedRes] = await Promise.all([
+      fetch(`${supabaseUrl}/rest/v1/questions?status=eq.active&select=id,question_text`, { headers }),
+      fetch(`${supabaseUrl}/rest/v1/questions?status=eq.closed&select=id,question_text`, { headers }),
+    ]);
+    if (activeRes.ok) setActiveQuestions(await activeRes.json());
+    if (closedRes.ok) setClosedQuestions(await closedRes.json());
+  };
+
+  useEffect(() => {
+    fetchQuestions();
+  }, []);
+
+  const deleteQuestion = async (id: string) => {
+    if (!supabaseUrl || !supabaseKey) return;
+    await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${id}`, {
+      method: 'DELETE',
+      headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+    });
+    fetchQuestions();
+  };
+
+  const renderList = (items: Question[]) => (
+    <ul className="space-y-2">
+      {items.map((q) => (
+        <li key={q.id} className="flex items-center justify-between">
+          <span>{q.question_text}</span>
+          <Button variant="destructive" size="sm" onClick={() => deleteQuestion(q.id)}>
+            Delete
+          </Button>
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div className="container mx-auto max-w-2xl space-y-8 py-8">
+      <section>
+        <h2 className="mb-4 text-xl font-semibold">Active Questions</h2>
+        {renderList(activeQuestions)}
+      </section>
+      <section>
+        <h2 className="mb-4 text-xl font-semibold">Closed Questions</h2>
+        {renderList(closedQuestions)}
+      </section>
+    </div>
+  );
+}

--- a/src/contexts/AdminGuard.tsx
+++ b/src/contexts/AdminGuard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from './AuthContext';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export default function AdminGuard({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [checking, setChecking] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    if (!loading && user && supabaseUrl && supabaseKey) {
+      fetch(`${supabaseUrl}/rest/v1/users?id=eq.${user.uid}&select=role`, {
+        headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+      })
+        .then((res) => (res.ok ? res.json() : []))
+        .then((data) => {
+          if (Array.isArray(data) && data[0]?.role === 'admin') {
+            setIsAdmin(true);
+          } else {
+            router.replace('/');
+          }
+          setChecking(false);
+        })
+        .catch(() => {
+          router.replace('/');
+          setChecking(false);
+        });
+    } else if (!loading && !user) {
+      router.replace('/login');
+      setChecking(false);
+    }
+  }, [user, loading, router]);
+
+  if (loading || checking) {
+    return null;
+  }
+
+  return isAdmin ? <>{children}</> : null;
+}

--- a/supabase/migrations/0002_admin_policies.sql
+++ b/supabase/migrations/0002_admin_policies.sql
@@ -1,0 +1,13 @@
+-- Add role to users for admin support
+alter table public.users add column if not exists role text not null default 'user';
+
+-- Track question status
+alter table public.questions add column if not exists status text not null default 'active';
+
+-- Allow admins to update and delete any question
+create policy "Admins can update any question" on public.questions
+  for update using (auth.jwt()->>'role' = 'admin')
+  with check (auth.jwt()->>'role' = 'admin');
+
+create policy "Admins can delete any question" on public.questions
+  for delete using (auth.jwt()->>'role' = 'admin');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,12 +1,12 @@
-insert into public.users (id, username)
+insert into public.users (id, username, role)
 values
-  ('00000000-0000-0000-0000-000000000001', 'alice'),
-  ('00000000-0000-0000-0000-000000000002', 'bob');
+  ('00000000-0000-0000-0000-000000000001', 'alice', 'admin'),
+  ('00000000-0000-0000-0000-000000000002', 'bob', 'user');
 
-insert into public.questions (id, user_id, title, body)
+insert into public.questions (id, user_id, title, body, status)
 values
-  ('00000000-0000-0000-0000-000000000101', '00000000-0000-0000-0000-000000000001', 'What is Supabase?', 'Can someone explain what Supabase is?'),
-  ('00000000-0000-0000-0000-000000000102', '00000000-0000-0000-0000-000000000002', 'How to use Next.js?', 'Looking for resources about Next.js.');
+  ('00000000-0000-0000-0000-000000000101', '00000000-0000-0000-0000-000000000001', 'What is Supabase?', 'Can someone explain what Supabase is?', 'active'),
+  ('00000000-0000-0000-0000-000000000102', '00000000-0000-0000-0000-000000000002', 'How to use Next.js?', 'Looking for resources about Next.js.', 'closed');
 
 insert into public.comments (id, question_id, user_id, content)
 values


### PR DESCRIPTION
## Summary
- add admin-protected pages listing active and closed questions
- gate admin routes with role-aware guard
- seed admin user and policies for editing or deleting questions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`
- `npm run build` *(fails: FirebaseError: auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68a63cdd1e948331aa87b6ecc0e43a0b