### PR TITLE
Add poll creation and redirect

### DIFF
--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -1,12 +1,51 @@
+"use client";
+
 import Link from 'next/link';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Header from '@/components/Header';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { ArrowLeft } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function NewPollPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const [question, setQuestion] = useState("");
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!question.trim() || !supabaseUrl || !supabaseKey || !user) return;
+
+    const expiresAt = new Date();
+    expiresAt.setMonth(expiresAt.getMonth() + 1);
+
+    await fetch(`${supabaseUrl}/rest/v1/questions`, {
+      method: 'POST',
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        question_text: question.trim(),
+        author_id: user.uid,
+        yes_votes: 0,
+        no_votes: 0,
+        comments_count: 0,
+        expires_at: expiresAt.toISOString(),
+      }),
+    });
+
+    router.push('/');
+  };
+
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
@@ -16,28 +55,33 @@ export default function NewPollPage() {
           Back to polls
         </Link>
         <Card>
-          <CardHeader>
-            <CardTitle>Create a new poll</CardTitle>
-            <CardDescription>
-              What question is on your mind?
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form>
+          <form onSubmit={handleSubmit} className="flex flex-col">
+            <CardHeader>
+              <CardTitle>Create a new poll</CardTitle>
+              <CardDescription>
+                What question is on your mind?
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
               <div className="grid w-full items-center gap-4">
                 <div className="flex flex-col space-y-1.5">
                   <Label htmlFor="question">Your Question</Label>
-                  <Textarea id="question" placeholder="e.g., Is pineapple on pizza a crime?" />
+                  <Textarea
+                    id="question"
+                    placeholder="e.g., Is pineapple on pizza a crime?"
+                    value={question}
+                    onChange={(e) => setQuestion(e.target.value)}
+                  />
                 </div>
               </div>
-            </form>
-          </CardContent>
-          <CardFooter className="flex justify-end gap-2">
-            <Button variant="outline" asChild>
+            </CardContent>
+            <CardFooter className="flex justify-end gap-2">
+              <Button variant="outline" asChild>
                 <Link href="/">Cancel</Link>
-            </Button>
-            <Button>Create Poll</Button>
-          </CardFooter>
+              </Button>
+              <Button type="submit">Create Poll</Button>
+            </CardFooter>
+          </form>
         </Card>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add client-side poll submission that posts to Supabase and redirects home

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a63cd933f0833187a3f5172a138b8a