### PR TITLE
Sanitize chart config values

### DIFF
--- a/src/components/ui/chart.test.tsx
+++ b/src/components/ui/chart.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react"
+import { ChartStyle, type ChartConfig } from "./chart"
+
+describe("ChartStyle sanitization", () => {
+  it("drops unsafe CSS values", () => {
+    const config: ChartConfig = {
+      safe: { color: "red" },
+      unsafe: { color: "red; background:url('javascript:alert(1)')" },
+    }
+
+    const { container } = render(<ChartStyle id="test" config={config} />)
+    const style = container.querySelector("style")
+    expect(style).toBeTruthy()
+    const html = style!.innerHTML
+
+    expect(html).toContain("--color-safe: red;")
+    expect(html).not.toContain("javascript")
+    expect(html).not.toContain("--color-unsafe")
+  })
+})


### PR DESCRIPTION
## Summary
- sanitize chart config variable names and CSS values to prevent injection
- add unit test covering unsafe color handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf85747ec8331980befa88782b150