### PR TITLE
Use shared Firebase UID-to-UUID helper across client and server

### DIFF
--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -11,26 +11,7 @@ import { Label } from '@/components/ui/label';
 import { ArrowLeft } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
-
-  // Function to generate UUID from Firebase UID (same as in AuthContext)
-  const generateUUID = (str: string) => {
-    // Create a simple hash from the string
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      const char = str.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-    
-    // Convert to a proper UUID format (36 characters: 8-4-4-4-12)
-    const hashStr = Math.abs(hash).toString(16).padStart(8, '0');
-    const uuid = `${hashStr.slice(0, 8)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 12)}`;
-    
-    // Ensure it's exactly 36 characters by padding if needed
-    const paddedUuid = uuid.padEnd(36, '0');
-    
-    return paddedUuid;
-  };
+import { firebaseUidToUuid } from '@/lib/id';
 
 export default function NewPollPage() {
   const { user } = useAuth();
@@ -70,6 +51,7 @@ export default function NewPollPage() {
       expiresAt.setMonth(expiresAt.getMonth() + 1);
 
       const idToken = await user.getIdToken();
+      const userId = firebaseUidToUuid(user.uid);
       const response = await fetch(`/api/questions`, {
         method: 'POST',
         headers: {
@@ -83,6 +65,7 @@ export default function NewPollPage() {
           no_votes: 0,
           comments_count: 0,
           expires_at: expiresAt.toISOString(),
+          user_id: userId,
         }),
       });
 

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -11,26 +11,7 @@ import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
-
-// Function to generate UUID from Firebase UID (same as in AuthContext)
-const generateUUID = (str: string) => {
-  // Create a simple hash from the string
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32-bit integer
-  }
-  
-  // Convert to a proper UUID format (36 characters: 8-4-4-4-12)
-  const hashStr = Math.abs(hash).toString(16).padStart(8, '0');
-  const uuid = `${hashStr.slice(0, 8)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 12)}`;
-  
-  // Ensure it's exactly 36 characters by padding if needed
-  const paddedUuid = uuid.padEnd(36, '0');
-  
-  return paddedUuid;
-};
+import { firebaseUidToUuid } from "@/lib/id";
 
 export default function QuestionCard({ question }: { question: Question }) {
   const { user } = useAuth();
@@ -53,7 +34,7 @@ export default function QuestionCard({ question }: { question: Question }) {
     setUserVote(vote);
 
     try {
-      const userId = generateUUID(user.uid);
+      const userId = firebaseUidToUuid(user.uid);
       const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
       const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
       

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import type { Question, FollowResponse, QuestionResponse } from "@/types";
+import { firebaseUidToUuid } from "@/lib/id";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -16,26 +17,6 @@ console.log('Environment variables:', {
 
 type QuestionWithAuthorId = Question & { authorId: string };
 
-       // Function to generate UUID from Firebase UID (same as in AuthContext)
-       const generateUUID = (str: string) => {
-         // Create a simple hash from the string
-         let hash = 0;
-         for (let i = 0; i < str.length; i++) {
-           const char = str.charCodeAt(i);
-           hash = ((hash << 5) - hash) + char;
-           hash = hash & hash; // Convert to 32-bit integer
-         }
-         
-         // Convert to a proper UUID format (36 characters: 8-4-4-4-12)
-         const hashStr = Math.abs(hash).toString(16).padStart(8, '0');
-         const uuid = `${hashStr.slice(0, 8)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 12)}`;
-         
-         // Ensure it's exactly 36 characters by padding if needed
-         const paddedUuid = uuid.padEnd(36, '0');
-         
-         return paddedUuid;
-       };
-
 export function useFeed(pageSize = 10) {
   const { user } = useAuth();
   const [questions, setQuestions] = useState<QuestionWithAuthorId[]>([]);
@@ -48,7 +29,7 @@ export function useFeed(pageSize = 10) {
     if (!user || !supabaseUrl || !supabaseKey) return [];
     
     try {
-      const userId = generateUUID(user.uid);
+      const userId = firebaseUidToUuid(user.uid);
       console.log('Fetching follows for user ID:', userId);
       
       const res = await fetch(

--- a/src/lib/id.test.ts
+++ b/src/lib/id.test.ts
@@ -1,0 +1,12 @@
+import { firebaseUidToUuid } from './id';
+
+describe('firebaseUidToUuid', () => {
+  it('generates consistent UUID for the same UID on client and server', () => {
+    const uid = 'test-uid';
+    const clientId = firebaseUidToUuid(uid);
+    const serverId = firebaseUidToUuid(uid);
+    const expected = 'bbf89759-e31e-5e6e-b368-1bbf7ba2cce3';
+    expect(clientId).toBe(expected);
+    expect(serverId).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- replace ad-hoc `generateUUID` implementations with `firebaseUidToUuid`
- propagate deterministic user IDs when creating polls
- add regression test asserting consistent ID generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adfa705950833188933e8d84ed7cd9