### PR TITLE
Encode identifiers in REST URLs

### DIFF
--- a/src/app/admin/page.test.tsx
+++ b/src/app/admin/page.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const toastMock = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+describe('AdminPage URL encoding', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+    global.fetch = jest.fn((url, options) => {
+      if (options && options.method === 'DELETE') {
+        return Promise.resolve({ ok: true });
+      }
+      if ((url as string).includes('status=eq.active')) {
+        return Promise.resolve({ ok: true, json: async () => [{ id: 'id/with?special', question_text: 'Q' }] });
+      }
+      if ((url as string).includes('status=eq.closed')) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }) as any;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('encodes id when deleting a question', async () => {
+    const { default: AdminPage } = await import('./page');
+    render(<AdminPage />);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    const deleteButton = await screen.findByText('Delete');
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      const encoded = encodeURIComponent('id/with?special');
+      expect(fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining(`id=eq.${encoded}`),
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+});
+

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
@@ -78,7 +78,7 @@ export default function AdminPage() {
     setDeletingIds(prev => new Set(prev).add(id));
 
     try {
-      const response = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${id}`, {
+      const response = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${encodeURIComponent(id)}`, {
         method: 'DELETE',
         headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
       });

--- a/src/components/QuestionCard.test.tsx
+++ b/src/components/QuestionCard.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QuestionCard from './QuestionCard';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn().mockReturnThis(),
+    })),
+    removeChannel: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/ui/avatar', () => {
+  const React = require('react');
+  const Avatar = ({ children }) => <div>{children}</div>;
+  const AvatarImage = ({ src, alt }) => <img src={src} alt={alt} />;
+  const AvatarFallback = ({ children }) => <span>{children}</span>;
+  return { Avatar, AvatarImage, AvatarFallback };
+});
+
+jest.mock('lucide-react', () => ({
+  MessageCircle: (props: any) => <svg {...props} />,
+}));
+
+describe('QuestionCard URL encoding', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { uid: 'user', getIdToken: jest.fn().mockResolvedValue('token') },
+    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}), text: async () => '' })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [{ yes_votes: 0, no_votes: 0 }] })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [{ yes_votes: 0, no_votes: 0 }] });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('encodes question id in REST calls', async () => {
+    const question = {
+      id: 'a/b?c=d',
+      author: { name: 'Alice', avatarUrl: '' },
+      questionText: 'Is encoding correct?',
+      initialYesVotes: 0,
+      initialNoVotes: 0,
+      commentsCount: 0,
+      createdAt: 'today',
+    } as any;
+
+    render(<QuestionCard question={question} />);
+
+    fireEvent.click(screen.getByText(question.questionText));
+    fireEvent.click(await screen.findByText('Yes'));
+
+    await waitFor(() => {
+      const encoded = encodeURIComponent(question.id);
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining(`id=eq.${encoded}`), expect.any(Object));
+    });
+  });
+});
+

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -96,7 +96,7 @@ export default function QuestionCard({ question }: { question: Question }) {
       }
       // After successful POST (fresh insert), fetch counts
       try {
-        const countsRes = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${question.id}&select=yes_votes,no_votes`, {
+        const countsRes = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${encodeURIComponent(question.id)}&select=yes_votes,no_votes`, {
           headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
         });
         if (countsRes.ok) {
@@ -109,7 +109,7 @@ export default function QuestionCard({ question }: { question: Question }) {
       } catch (ignored) {}
 
       // Update question vote counts
-      const questionResponse = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${question.id}&select=yes_votes,no_votes`, {
+      const questionResponse = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${encodeURIComponent(question.id)}&select=yes_votes,no_votes`, {
         headers: {
           apikey: supabaseKey,
           Authorization: `Bearer ${supabaseKey}`,

--- a/src/hooks/useFeed.test.ts
+++ b/src/hooks/useFeed.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+describe('useFeed URL encoding', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('encodes dynamic parameters in fetch URLs', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { uid: 'user/id?test' },
+    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: '1',
+            question_text: 'q',
+            yes_votes: 0,
+            no_votes: 0,
+            comments_count: 0,
+            created_at: 'now',
+            user_id: 'author/id?name',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ name: 'Auth', avatar_url: '' }] });
+
+    const { useFeed } = await import('./useFeed');
+    renderHook(() => useFeed());
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+
+    const generateUUID = (str: string) => {
+      let hash = 0;
+      for (let i = 0; i < str.length; i++) {
+        const char = str.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash;
+      }
+      const hashStr = Math.abs(hash).toString(16).padStart(8, '0');
+      const uuid = `${hashStr.slice(0, 8)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 12)}`;
+      return uuid.padEnd(36, '0');
+    };
+    const encodedUserId = encodeURIComponent(generateUUID('user/id?test'));
+    const encodedAuthorId = encodeURIComponent('author/id?name');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`follower_id=eq.${encodedUserId}`),
+      expect.any(Object)
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/profiles?id=eq.${encodedAuthorId}`),
+      expect.any(Object)
+    );
+  });
+});
+

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -52,7 +52,7 @@ export function useFeed(pageSize = 10) {
       console.log('Fetching follows for user ID:', userId);
       
       const res = await fetch(
-        `${supabaseUrl}/rest/v1/follows?select=following_id&follower_id=eq.${userId}`,
+        `${supabaseUrl}/rest/v1/follows?select=following_id&follower_id=eq.${encodeURIComponent(userId)}`,
         {
           headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
         }
@@ -125,7 +125,7 @@ export function useFeed(pageSize = 10) {
                data.map(async (q: QuestionResponse) => {
                  try {
                    const profileRes = await fetch(
-                     `${supabaseUrl}/rest/v1/profiles?id=eq.${q.user_id}`,
+                     `${supabaseUrl}/rest/v1/profiles?id=eq.${encodeURIComponent(q.user_id)}`,
               {
                 headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
               }


### PR DESCRIPTION
## Summary
- URL-encode question IDs in QuestionCard REST calls
- Encode dynamic parameters in useFeed hook and admin delete endpoint
- Add tests for special-character IDs to keep URLs valid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfb4adc8c833197aa74754bdcd6a3