### PR TITLE
Secure admin checks via server API

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+import { useAuth } from '@/contexts/AuthContext';
 
 type Question = { id: string; question_text: string };
 
 export default function AdminPage() {
+  const { user } = useAuth();
   const { toast } = useToast();
   const [activeQuestions, setActiveQuestions] = useState<Question[]>([]);
   const [closedQuestions, setClosedQuestions] = useState<Question[]>([]);
@@ -18,31 +17,25 @@ export default function AdminPage() {
   const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
 
   const fetchQuestions = useCallback(async () => {
-    if (!supabaseUrl || !supabaseKey) {
-      toast({
-        title: "Configuration error",
-        description: "Unable to load questions. Please check your configuration.",
-        variant: "destructive",
-      });
-      return;
-    }
+    if (!user) return;
 
     setLoading(true);
-    const headers = { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` };
-    
     try {
+      const token = await user.getIdToken();
+      const headers = { Authorization: `Bearer ${token}` };
+
       const [activeRes, closedRes] = await Promise.all([
-        fetch(`${supabaseUrl}/rest/v1/questions?status=eq.active&select=id,question_text`, { headers }),
-        fetch(`${supabaseUrl}/rest/v1/questions?status=eq.closed&select=id,question_text`, { headers }),
+        fetch(`/api/admin/questions?status=active`, { headers }),
+        fetch(`/api/admin/questions?status=closed`, { headers }),
       ]);
-      
+
       if (activeRes.ok) {
         const activeData = await activeRes.json();
         setActiveQuestions(activeData);
       } else {
         console.error('Failed to fetch active questions:', activeRes.status, activeRes.statusText);
       }
-      
+
       if (closedRes.ok) {
         const closedData = await closedRes.json();
         setClosedQuestions(closedData);
@@ -52,25 +45,25 @@ export default function AdminPage() {
     } catch (error) {
       console.error('Error fetching questions:', error);
       toast({
-        title: "Failed to load questions",
-        description: "An error occurred while loading questions. Please try again.",
-        variant: "destructive",
+        title: 'Failed to load questions',
+        description: 'An error occurred while loading questions. Please try again.',
+        variant: 'destructive',
       });
     } finally {
       setLoading(false);
     }
-  }, [toast]);
+  }, [toast, user]);
 
   useEffect(() => {
     fetchQuestions();
   }, [fetchQuestions]);
 
   const deleteQuestion = async (id: string) => {
-    if (!supabaseUrl || !supabaseKey) {
+    if (!user) {
       toast({
-        title: "Configuration error",
-        description: "Unable to delete question. Please check your configuration.",
-        variant: "destructive",
+        title: 'Authentication required',
+        description: 'Please sign in to delete questions.',
+        variant: 'destructive',
       });
       return;
     }
@@ -78,9 +71,10 @@ export default function AdminPage() {
     setDeletingIds(prev => new Set(prev).add(id));
 
     try {
-      const response = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${id}`, {
+      const token = await user.getIdToken();
+      const response = await fetch(`/api/admin/questions/${id}`, {
         method: 'DELETE',
-        headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+        headers: { Authorization: `Bearer ${token}` },
       });
 
       if (!response.ok) {
@@ -89,18 +83,17 @@ export default function AdminPage() {
       }
 
       toast({
-        title: "Question deleted",
-        description: "The question has been successfully deleted.",
+        title: 'Question deleted',
+        description: 'The question has been successfully deleted.',
       });
 
-      // Refresh the questions list
       await fetchQuestions();
     } catch (error) {
       console.error('Error deleting question:', error);
       toast({
-        title: "Failed to delete question",
-        description: error instanceof Error ? error.message : "An unexpected error occurred. Please try again.",
-        variant: "destructive",
+        title: 'Failed to delete question',
+        description: error instanceof Error ? error.message : 'An unexpected error occurred. Please try again.',
+        variant: 'destructive',
       });
     } finally {
       setDeletingIds(prev => {
@@ -126,13 +119,13 @@ export default function AdminPage() {
             {items.map((q) => (
               <li key={q.id} className="flex items-center justify-between p-3 border rounded-lg">
                 <span className="flex-1 mr-4">{q.question_text}</span>
-                <Button 
-                  variant="destructive" 
-                  size="sm" 
+                <Button
+                  variant="destructive"
+                  size="sm"
                   onClick={() => deleteQuestion(q.id)}
                   disabled={deletingIds.has(q.id)}
                 >
-                  {deletingIds.has(q.id) ? "Deleting..." : "Delete"}
+                  {deletingIds.has(q.id) ? 'Deleting...' : 'Delete'}
                 </Button>
               </li>
             ))}
@@ -148,10 +141,10 @@ export default function AdminPage() {
         <h1 className="text-3xl font-bold mb-2">Admin Dashboard</h1>
         <p className="text-muted-foreground">Manage polls and questions</p>
       </div>
-      
+
       <div className="grid gap-8 md:grid-cols-2">
-        {renderList(activeQuestions, "Active Questions")}
-        {renderList(closedQuestions, "Closed Questions")}
+        {renderList(activeQuestions, 'Active Questions')}
+        {renderList(closedQuestions, 'Closed Questions')}
       </div>
     </div>
   );

--- a/src/app/api/admin/check/route.ts
+++ b/src/app/api/admin/check/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyFirebaseIdToken } from '@/lib/firebaseAdmin';
+import { firebaseUidToUuid } from '@/lib/id';
+import { getSupabaseService } from '@/lib/supabaseService';
+
+export const runtime = 'nodejs';
+
+export async function GET(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get('authorization') || '';
+    const [, token] = authHeader.split(' ');
+    if (!token) {
+      return NextResponse.json({ message: 'Missing Authorization Bearer token' }, { status: 401 });
+    }
+
+    const decoded = await verifyFirebaseIdToken(token);
+    const userId = firebaseUidToUuid(decoded.uid);
+
+    const supabase = getSupabaseService();
+    const { data, error } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', userId)
+      .single();
+
+    if (error) {
+      return NextResponse.json({ message: 'Role lookup failed', details: error.message }, { status: 500 });
+    }
+
+    if (data?.role !== 'admin') {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err: any) {
+    return NextResponse.json({ message: 'Admin check failed', details: err?.message || String(err) }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/questions/[id]/route.ts
+++ b/src/app/api/admin/questions/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyFirebaseIdToken } from '@/lib/firebaseAdmin';
+import { firebaseUidToUuid } from '@/lib/id';
+import { getSupabaseService } from '@/lib/supabaseService';
+
+export const runtime = 'nodejs';
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const authHeader = req.headers.get('authorization') || '';
+    const [, token] = authHeader.split(' ');
+    if (!token) {
+      return NextResponse.json({ message: 'Missing Authorization Bearer token' }, { status: 401 });
+    }
+
+    const decoded = await verifyFirebaseIdToken(token);
+    const userId = firebaseUidToUuid(decoded.uid);
+    const supabase = getSupabaseService();
+
+    const { data: roleData, error: roleErr } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', userId)
+      .single();
+    if (roleErr || roleData?.role !== 'admin') {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+    }
+
+    const { error } = await supabase
+      .from('questions')
+      .delete()
+      .eq('id', params.id);
+    if (error) {
+      return NextResponse.json({ message: 'Delete failed', details: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err: any) {
+    return NextResponse.json({ message: 'Delete question failed', details: err?.message || String(err) }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/questions/route.ts
+++ b/src/app/api/admin/questions/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyFirebaseIdToken } from '@/lib/firebaseAdmin';
+import { firebaseUidToUuid } from '@/lib/id';
+import { getSupabaseService } from '@/lib/supabaseService';
+
+export const runtime = 'nodejs';
+
+async function assertAdmin(token: string) {
+  const decoded = await verifyFirebaseIdToken(token);
+  const userId = firebaseUidToUuid(decoded.uid);
+  const supabase = getSupabaseService();
+  const { data, error } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', userId)
+    .single();
+  if (error || data?.role !== 'admin') {
+    throw new Error('not-admin');
+  }
+  return supabase;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get('authorization') || '';
+    const [, token] = authHeader.split(' ');
+    if (!token) {
+      return NextResponse.json({ message: 'Missing Authorization Bearer token' }, { status: 401 });
+    }
+
+    const supabase = await assertAdmin(token);
+    const status = req.nextUrl.searchParams.get('status');
+    let query = supabase.from('questions').select('id,question_text,status');
+    if (status) {
+      query = query.eq('status', status);
+    }
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ message: 'Fetch failed', details: error.message }, { status: 400 });
+    }
+    return NextResponse.json(data, { status: 200 });
+  } catch (err: any) {
+    if (err.message === 'not-admin') {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+    }
+    return NextResponse.json({ message: 'Fetch questions failed', details: err?.message || String(err) }, { status: 500 });
+  }
+}

--- a/src/contexts/AdminGuard.tsx
+++ b/src/contexts/AdminGuard.tsx
@@ -5,9 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from './AuthContext';
 import { useToast } from '@/hooks/use-toast';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
 export default function AdminGuard({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth();
   const { toast } = useToast();
@@ -16,44 +13,40 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    if (!loading && user && supabaseUrl && supabaseKey) {
-      fetch(`${supabaseUrl}/rest/v1/users?id=eq.${user.uid}&select=role`, {
-        headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
-      })
-        .then((res) => {
-          if (!res.ok) {
-            throw new Error(`Failed to check admin status: ${res.status} ${res.statusText}`);
-          }
-          return res.json();
-        })
-        .then((data) => {
-          if (Array.isArray(data) && data[0]?.role === 'admin') {
+    if (!loading && user) {
+      (async () => {
+        try {
+          const token = await user.getIdToken();
+          const res = await fetch('/api/admin/check', {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (res.ok) {
             setIsAdmin(true);
           } else {
             toast({
-              title: "Access denied",
+              title: 'Access denied',
               description: "You don't have permission to access this page.",
-              variant: "destructive",
+              variant: 'destructive',
             });
             router.replace('/');
           }
-          setChecking(false);
-        })
-        .catch((error) => {
+        } catch (error) {
           console.error('Error checking admin status:', error);
           toast({
-            title: "Error",
-            description: "Failed to verify admin permissions. Please try again.",
-            variant: "destructive",
+            title: 'Error',
+            description: 'Failed to verify admin permissions. Please try again.',
+            variant: 'destructive',
           });
           router.replace('/');
+        } finally {
           setChecking(false);
-        });
+        }
+      })();
     } else if (!loading && !user) {
       toast({
-        title: "Authentication required",
-        description: "Please sign in to access this page.",
-        variant: "destructive",
+        title: 'Authentication required',
+        description: 'Please sign in to access this page.',
+        variant: 'destructive',
       });
       router.replace('/login');
       setChecking(false);


### PR DESCRIPTION
## Summary
- add server API endpoints for admin check and privileged question management
- call server admin check in `AdminGuard` instead of client-side role fetch
- use secure endpoints for admin question list and deletion

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Property 'ip' does not exist on type 'NextRequest', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68adfc40c3588331ac97cc3154179191