### PR TITLE
feat: persist rate limiter with supabase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "embla-carousel-react": "^8.6.0",
         "firebase": "^11.9.1",
         "firebase-admin": "^13.4.0",
-        "lru-cache": "^11.1.0",
         "lucide-react": "^0.475.0",
         "next": "15.3.3",
         "patch-package": "^8.0.0",
@@ -10959,14 +10958,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/lru-memoizer": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "embla-carousel-react": "^8.6.0",
     "firebase": "^11.9.1",
     "firebase-admin": "^13.4.0",
-    "lru-cache": "^11.1.0",
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
     "patch-package": "^8.0.0",

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -6,7 +6,6 @@ import rateLimit from '@/lib/rate-limiter';
 
 const limiter = rateLimit({
   interval: 60 * 1000, // 60 seconds
-  uniqueTokenPerInterval: 500, // 500 users per interval
 });
 
 export const runtime = 'nodejs';

--- a/src/app/api/users/sync/route.ts
+++ b/src/app/api/users/sync/route.ts
@@ -7,7 +7,6 @@ import rateLimit from '@/lib/rate-limiter';
 
 const limiter = rateLimit({
   interval: 60 * 1000, // 60 seconds
-  uniqueTokenPerInterval: 500, // 500 users per interval
 });
 
 const bodySchema = z.object({

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -6,7 +6,6 @@ import rateLimit from '@/lib/rate-limiter';
 
 const limiter = rateLimit({
   interval: 60 * 1000, // 60 seconds
-  uniqueTokenPerInterval: 500, // 500 users per interval
 });
 
 export const runtime = 'nodejs';

--- a/src/lib/__tests__/rate-limiter.test.ts
+++ b/src/lib/__tests__/rate-limiter.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment node
+ */
+
+import rateLimit, { RateLimitStore } from '@/lib/rate-limiter';
+
+class MemoryStore implements RateLimitStore {
+  private store = new Map<string, { count: number; expiresAt: number }>();
+
+  async increment(token: string, interval: number): Promise<number> {
+    const now = Date.now();
+    const entry = this.store.get(token);
+    if (!entry || entry.expiresAt < now) {
+      const newEntry = { count: 1, expiresAt: now + interval };
+      this.store.set(token, newEntry);
+      return 1;
+    }
+    entry.count += 1;
+    return entry.count;
+  }
+}
+
+describe('rate limiter', () => {
+  it('blocks requests across instances', async () => {
+    const store = new MemoryStore();
+    const limiterA = rateLimit({ interval: 1000, store });
+    const limiterB = rateLimit({ interval: 1000, store });
+
+    const token = 'test-token';
+
+    await limiterA.check(3, token);
+    await limiterB.check(3, token);
+    await limiterA.check(3, token);
+    await expect(limiterB.check(3, token)).rejects.toThrow('Rate limit exceeded');
+  });
+});

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -1,33 +1,69 @@
-import { LRUCache } from 'lru-cache';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export interface RateLimitStore {
+  increment(token: string, interval: number): Promise<number>;
+}
+
+class SupabaseStore implements RateLimitStore {
+  private client: SupabaseClient;
+
+  constructor(client?: SupabaseClient) {
+    if (client) {
+      this.client = client;
+    } else {
+      const url = process.env.SUPABASE_URL;
+      const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+      if (!url || !key) {
+        throw new Error('Supabase credentials are not configured');
+      }
+      this.client = createClient(url, key);
+    }
+  }
+
+  async increment(token: string, interval: number): Promise<number> {
+    const now = Date.now();
+    const expiresAt = new Date(now + interval).toISOString();
+
+    const { data, error } = await this.client
+      .from('rate_limits')
+      .select('count, expires_at')
+      .eq('token', token)
+      .single();
+
+    if (error || !data || new Date(data.expires_at).getTime() < now) {
+      const { error: upsertErr } = await this.client
+        .from('rate_limits')
+        .upsert({ token, count: 1, expires_at: expiresAt });
+      if (upsertErr) throw upsertErr;
+      return 1;
+    }
+
+    const newCount = data.count + 1;
+    const { error: updateErr } = await this.client
+      .from('rate_limits')
+      .update({ count: newCount, expires_at: expiresAt })
+      .eq('token', token);
+    if (updateErr) throw updateErr;
+    return newCount;
+  }
+}
 
 type Options = {
-  uniqueTokenPerInterval?: number;
   interval?: number;
+  store?: RateLimitStore;
+  supabaseClient?: SupabaseClient;
 };
 
-export default function rateLimit(options?: Options) {
-  const tokenCache = new LRUCache({
-    max: options?.uniqueTokenPerInterval || 500,
-    ttl: options?.interval || 60000,
-  });
-
+export default function rateLimit(options: Options = {}) {
+  const interval = options.interval ?? 60000;
+  const store = options.store ?? new SupabaseStore(options.supabaseClient);
   return {
-    check: (limit: number, token: string) =>
-      new Promise<void>((resolve, reject) => {
-        const tokenCount = (tokenCache.get(token) as number[]) || [0];
-        if (tokenCount[0] === 0) {
-          tokenCache.set(token, tokenCount);
-        }
-        tokenCount[0] += 1;
-
-        const currentUsage = tokenCount[0];
-        const isRateLimited = currentUsage >= limit;
-
-        if (isRateLimited) {
-          reject(new Error('Rate limit exceeded'));
-        } else {
-          resolve();
-        }
-      }),
+    check: async (limit: number, token: string) => {
+      const current = await store.increment(token, interval);
+      if (current > limit) {
+        throw new Error('Rate limit exceeded');
+      }
+    },
   };
 }
+export { SupabaseStore };


### PR DESCRIPTION
## Summary
- replace in-memory rate limiter with Supabase-backed store
- update API routes to use new persistent limiter
- add tests for cross-instance request limits

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find name 'useCallback'; NextRequest lacks 'ip'; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68adfc3dbb888331809f3d440c408ce5