### PR TITLE
Restrict anonymous access and test auth

### DIFF
--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyFirebaseIdToken } from '@/lib/firebaseAdmin';
+import { firebaseUidToUuid } from '@/lib/id';
+import { getSupabaseForUser } from '@/lib/supabaseRls';
+import rateLimit from '@/lib/rate-limiter';
+
+const limiter = rateLimit({
+  interval: 60 * 1000,
+  uniqueTokenPerInterval: 500,
+});
+
+export const runtime = 'nodejs';
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const ip = req.ip ?? '127.0.0.1';
+    await limiter.check(5, ip); // 5 requests per minute per IP
+
+    const authHeader = req.headers.get('authorization') || '';
+    const [, token] = authHeader.split(' ');
+    if (!token) return NextResponse.json({ message: 'Missing Authorization Bearer token' }, { status: 401 });
+
+    let decoded;
+    try {
+      decoded = await verifyFirebaseIdToken(token);
+    } catch {
+      return NextResponse.json({ message: 'Invalid token' }, { status: 403 });
+    }
+    const userId = firebaseUidToUuid(decoded.uid);
+    const supabase = getSupabaseForUser(userId);
+
+    const { error } = await supabase.from('questions').delete().eq('id', params.id);
+    if (error) return NextResponse.json({ message: 'Delete failed', details: error.message }, { status: 400 });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err: any) {
+    if (err.message === 'Rate limit exceeded') {
+      return NextResponse.json({ message: 'Rate limit exceeded' }, { status: 429 });
+    }
+    return NextResponse.json({ message: 'Delete question failed', details: err?.message || String(err) }, { status: 500 });
+  }
+}

--- a/src/app/api/questions/route.test.ts
+++ b/src/app/api/questions/route.test.ts
@@ -1,0 +1,46 @@
+/** @jest-environment node */
+
+import { POST } from '@/app/api/questions/route';
+import { DELETE } from '@/app/api/questions/[id]/route';
+
+jest.mock('@/lib/firebaseAdmin', () => ({
+  verifyFirebaseIdToken: jest.fn().mockRejectedValue(new Error('Invalid token')),
+}));
+
+describe('questions API auth', () => {
+  it('returns 401 when no token provided on POST', async () => {
+    const req = new Request('http://localhost/api/questions', {
+      method: 'POST',
+      body: JSON.stringify({ question_text: 'Hi', title: 'T' }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with invalid token on POST', async () => {
+    const req = new Request('http://localhost/api/questions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer bad' },
+      body: JSON.stringify({ question_text: 'Hi', title: 'T' }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when no token provided on DELETE', async () => {
+    const req = new Request('http://localhost/api/questions/123', {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req as any, { params: { id: '123' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with invalid token on DELETE', async () => {
+    const req = new Request('http://localhost/api/questions/123', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer bad' },
+    });
+    const res = await DELETE(req as any, { params: { id: '123' } });
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -20,7 +20,12 @@ export async function POST(req: NextRequest) {
     const [, token] = authHeader.split(' ');
     if (!token) return NextResponse.json({ message: 'Missing Authorization Bearer token' }, { status: 401 });
 
-    const decoded = await verifyFirebaseIdToken(token);
+    let decoded;
+    try {
+      decoded = await verifyFirebaseIdToken(token);
+    } catch {
+      return NextResponse.json({ message: 'Invalid token' }, { status: 403 });
+    }
     const userId = firebaseUidToUuid(decoded.uid);
 
     const { question_text, title, expires_at } = await req.json();

--- a/src/app/api/votes/route.test.ts
+++ b/src/app/api/votes/route.test.ts
@@ -1,0 +1,28 @@
+/** @jest-environment node */
+
+import { POST } from '@/app/api/votes/route';
+
+jest.mock('@/lib/firebaseAdmin', () => ({
+  verifyFirebaseIdToken: jest.fn().mockRejectedValue(new Error('Invalid token')),
+}));
+
+describe('votes API auth', () => {
+  it('returns 401 when no token provided', async () => {
+    const req = new Request('http://localhost/api/votes', {
+      method: 'POST',
+      body: JSON.stringify({ question_id: '1', value: 1 }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with invalid token', async () => {
+    const req = new Request('http://localhost/api/votes', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer bad' },
+      body: JSON.stringify({ question_id: '1', value: 1 }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -20,7 +20,12 @@ export async function POST(req: NextRequest) {
     const [, token] = authHeader.split(' ');
     if (!token) return NextResponse.json({ message: 'Missing Authorization Bearer token' }, { status: 401 });
 
-    const decoded = await verifyFirebaseIdToken(token);
+    let decoded;
+    try {
+      decoded = await verifyFirebaseIdToken(token);
+    } catch {
+      return NextResponse.json({ message: 'Invalid token' }, { status: 403 });
+    }
     const userId = firebaseUidToUuid(decoded.uid);
     const supabase = getSupabaseForUser(userId);
 

--- a/supabase/migrations/0009_restrict_anon_select.sql
+++ b/supabase/migrations/0009_restrict_anon_select.sql
@@ -1,0 +1,53 @@
+-- Restrict read and delete access to authenticated users to prevent anonymous abuse
+
+-- Users
+DROP POLICY IF EXISTS "Users can view all users" ON public.users;
+CREATE POLICY "Users can view all users" ON public.users
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Profiles
+DROP POLICY IF EXISTS "Profiles are viewable by everyone" ON public.profiles;
+CREATE POLICY "Profiles viewable by authenticated" ON public.profiles
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Questions
+DROP POLICY IF EXISTS "Questions are viewable by everyone" ON public.questions;
+CREATE POLICY "Questions viewable by authenticated" ON public.questions
+  FOR SELECT TO authenticated
+  USING (true);
+DROP POLICY IF EXISTS "Users can only delete their own questions" ON public.questions;
+CREATE POLICY "Users delete own questions" ON public.questions
+  FOR DELETE TO authenticated
+  USING (auth.uid() = user_id);
+DROP POLICY IF EXISTS "Admins can delete any question" ON public.questions;
+CREATE POLICY "Admins delete any question" ON public.questions
+  FOR DELETE TO authenticated
+  USING (auth.jwt()->>'role' = 'admin');
+
+-- Votes
+DROP POLICY IF EXISTS "Users can view their own votes" ON public.votes;
+CREATE POLICY "Users view own votes" ON public.votes
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Comments
+DROP POLICY IF EXISTS "Comments are viewable by everyone" ON public.comments;
+CREATE POLICY "Comments viewable by authenticated" ON public.comments
+  FOR SELECT TO authenticated
+  USING (true);
+DROP POLICY IF EXISTS "Users can only delete their own comments" ON public.comments;
+CREATE POLICY "Users delete own comments" ON public.comments
+  FOR DELETE TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Follows
+DROP POLICY IF EXISTS "Follows are viewable by everyone" ON public.follows;
+CREATE POLICY "Follows viewable by authenticated" ON public.follows
+  FOR SELECT TO authenticated
+  USING (true);
+DROP POLICY IF EXISTS "Users can only delete their own follows" ON public.follows;
+CREATE POLICY "Users delete own follows" ON public.follows
+  FOR DELETE TO authenticated
+  USING (auth.uid() = follower_id);


### PR DESCRIPTION
## Summary
- tighten Supabase policies so only authenticated users can read or delete rows
- add JWT-protected question deletion route
- return 403 for invalid tokens and test unauthorized API access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfc3c956c8331acc44b8cd02db78b