### PR TITLE
Encode Supabase REST query params safely

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
+import { safeQueryParam } from '@/lib/utils';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -78,7 +79,7 @@ export default function AdminPage() {
     setDeletingIds(prev => new Set(prev).add(id));
 
     try {
-      const response = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${id}`, {
+      const response = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${safeQueryParam(id)}`, {
         method: 'DELETE',
         headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
       });

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress";
 import { MessageCircle } from "lucide-react";
 import type { Question } from "@/types";
-import { cn } from "@/lib/utils";
+import { cn, safeQueryParam } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
@@ -96,7 +96,7 @@ export default function QuestionCard({ question }: { question: Question }) {
       }
       // After successful POST (fresh insert), fetch counts
       try {
-        const countsRes = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${question.id}&select=yes_votes,no_votes`, {
+        const countsRes = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${safeQueryParam(question.id)}&select=yes_votes,no_votes`, {
           headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
         });
         if (countsRes.ok) {
@@ -109,7 +109,7 @@ export default function QuestionCard({ question }: { question: Question }) {
       } catch (ignored) {}
 
       // Update question vote counts
-      const questionResponse = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${question.id}&select=yes_votes,no_votes`, {
+      const questionResponse = await fetch(`${supabaseUrl}/rest/v1/questions?id=eq.${safeQueryParam(question.id)}&select=yes_votes,no_votes`, {
         headers: {
           apikey: supabaseKey,
           Authorization: `Bearer ${supabaseKey}`,

--- a/src/contexts/AdminGuard.tsx
+++ b/src/contexts/AdminGuard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from './AuthContext';
 import { useToast } from '@/hooks/use-toast';
+import { safeQueryParam } from '@/lib/utils';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -17,7 +18,7 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
 
   useEffect(() => {
     if (!loading && user && supabaseUrl && supabaseKey) {
-      fetch(`${supabaseUrl}/rest/v1/users?id=eq.${user.uid}&select=role`, {
+      fetch(`${supabaseUrl}/rest/v1/users?id=eq.${safeQueryParam(user.uid)}&select=role`, {
         headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
       })
         .then((res) => {

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import type { Question, FollowResponse, QuestionResponse } from "@/types";
+import { safeQueryParam } from "@/lib/utils";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -52,7 +53,7 @@ export function useFeed(pageSize = 10) {
       console.log('Fetching follows for user ID:', userId);
       
       const res = await fetch(
-        `${supabaseUrl}/rest/v1/follows?select=following_id&follower_id=eq.${userId}`,
+        `${supabaseUrl}/rest/v1/follows?select=following_id&follower_id=eq.${safeQueryParam(userId)}`,
         {
           headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
         }
@@ -125,7 +126,7 @@ export function useFeed(pageSize = 10) {
                data.map(async (q: QuestionResponse) => {
                  try {
                    const profileRes = await fetch(
-                     `${supabaseUrl}/rest/v1/profiles?id=eq.${q.user_id}`,
+                     `${supabaseUrl}/rest/v1/profiles?id=eq.${safeQueryParam(q.user_id)}`,
               {
                 headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
               }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,19 @@
+import { safeQueryParam } from '@/lib/utils';
+
+describe('safeQueryParam', () => {
+  it('encodes malicious input', () => {
+    const malicious = '?id=eq.1&or=(1=1)';
+    const encoded = safeQueryParam(malicious);
+    expect(encoded).toBe(encodeURIComponent(malicious));
+    expect(encoded).not.toContain(malicious);
+  });
+
+  it('produces safe Supabase URL segment', () => {
+    const base = 'https://example.supabase.co';
+    const malicious = '?id=eq.1&or=(1=1)';
+    const param = safeQueryParam(malicious);
+    const url = `${base}/rest/v1/users?id=eq.${param}`;
+    expect(url).toBe(`${base}/rest/v1/users?id=eq.${encodeURIComponent(malicious)}`);
+    expect(url).not.toContain(malicious);
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function safeQueryParam(value: string | number) {
+  return encodeURIComponent(String(value))
+}


### PR DESCRIPTION
## Summary
- add `safeQueryParam` helper to URL-encode dynamic parameters
- use `safeQueryParam` across Supabase REST fetches
- add tests covering malicious query inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfc3b711c8331b95c9c2f4b144b7a